### PR TITLE
Use RAII for loop registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CommonSources
     include/verify_cache.h
     src/verify_cache.cpp
     include/i_loop.h
+    src/i_loop.cpp
     include/loop.h
     src/loop.cpp
     include/server.h

--- a/include/forwarder_connection.h
+++ b/include/forwarder_connection.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "config_parser.h"
+#include "i_loop.h"
 #include "openssl/ssl_connection.h"
 
 #include <memory>
@@ -12,7 +13,6 @@
 
 namespace dote {
 
-class ILoop;
 class IForwarderConfig;
 class Socket;
 
@@ -93,8 +93,6 @@ class ForwarderConnection
     void configureVerifier();
 
     /// \brief  Perform the initial connection
-    ///
-    /// \param handle  The socket that is available to connect on
     void connect(int handle);
 
     /// \brief  Nicely shutdown the connection
@@ -136,6 +134,12 @@ class ForwarderConnection
     State m_state;
     /// The established connection to the forwarder
     std::shared_ptr<Socket> m_socket;
+    /// The current read registration for m_socket.
+    ILoop::Registration m_read;
+    /// The current write registration for m_socket.
+    ILoop::Registration m_write;
+    /// The current exception registration for m_socket.
+    ILoop::Registration m_exception;
     /// The write buffer, the request will be a single message
     std::vector<char> m_buffer;
     /// The chosen forwarder that this is connected to

--- a/include/i_loop.h
+++ b/include/i_loop.h
@@ -12,6 +12,72 @@ class ILoop
   public:
     virtual ~ILoop() = default;
 
+    /// \brief  A registration type.
+    enum Type {
+      /// A special value to avoid deregistering on move.
+      Moved,
+      /// A read registration.
+      Read,
+      /// A write registration.
+      Write,
+      /// An exception registration.
+      Exception,
+    };
+
+    /// \brief  This class is created with a read, write or exception
+    ///         registration and automatically removes the registration
+    ///         on destruction.
+    ///
+    /// NOTE: This object must not outlive the Loop that created it.
+    class Registration
+    {
+      public:
+        Registration(const Registration&) = delete;
+        Registration& operator=(const Registration&) = delete;
+
+        /// \brief  Construct an invalid Registration.
+        Registration();
+
+        /// \brief  Create a registration for a given loop.
+        ///
+        /// \param loop    The loop that this registration is for.
+        /// \param handle  The handle of the registration
+        /// \param type    The type of the registration.
+        Registration(ILoop* loop, int handle, Type type);
+
+        /// \brief  Take ownership of a registration.
+        ///
+        /// \param other  The instance to take ownership from.
+        Registration(Registration&& other);
+
+        /// \brief  Take ownership of a registration.
+        ///
+        /// \param other  The instance to take ownership from.
+        Registration& operator=(Registration&& other);
+
+        /// \brief  Deregister from the loop.
+        ~Registration();
+
+        operator bool() const { return valid(); }
+
+        /// \brief  Whether the registration is valid (i.e. the execution was
+        //          successful).
+        bool valid() const;
+
+        /// \brief  Clear the registration.
+        void reset();
+
+      private:
+        friend class ILoop;
+
+        /// The loop that this registration is for.
+        ILoop* m_loop;
+        /// The handle to deregister.
+        int m_handle;
+        /// The type of registration.
+        Type m_type;
+    };
+
     /// The type to call when the loop is available, called with the
     /// handle that caused it to be called
     using Callback = std::function<void(int)>;
@@ -23,7 +89,7 @@ class ILoop
     /// \param timeout  The time at which to call exception on the handle
     ///
     /// \return  True if the handle is not already registered and now is
-    virtual bool registerRead(int handle, Callback callback, time_t timeout) = 0;
+    virtual Registration registerRead(int handle, Callback callback, time_t timeout) = 0;
 
     /// \brief   Register for write availability on a given handle
     ///
@@ -32,7 +98,7 @@ class ILoop
     /// \param timeout  The time at which to call exception on the handle
     ///
     /// \return  True if the handle is not already registered and now is
-    virtual bool registerWrite(int handle, Callback callback, time_t timeout) = 0;
+    virtual Registration registerWrite(int handle, Callback callback, time_t timeout) = 0;
 
     /// \brief  Register for exceptions on a given handle
     ///
@@ -40,8 +106,9 @@ class ILoop
     /// \param callback  The callback to call if it triggers
     ///
     /// \return  True if the handle is not already registered and now is
-    virtual bool registerException(int handle, Callback callback) = 0;
+    virtual Registration registerException(int handle, Callback callback) = 0;
 
+  protected:
     /// \brief  Remove a read handle from the loop
     ///
     /// \param handle  The handle to remove read handles for

--- a/include/ip_lookup.h
+++ b/include/ip_lookup.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "i_loop.h"
+
 #include <memory>
 
 namespace dote {
@@ -50,6 +52,12 @@ class IpLookup
     std::shared_ptr<Loop> m_loop;
     /// The socket that the connection if performed on
     std::shared_ptr<Socket> m_socket;
+    /// The current read registration for m_socket.
+    ILoop::Registration m_read;
+    /// The current write registration for m_socket.
+    ILoop::Registration m_write;
+    /// The current exception registration for m_socket.
+    ILoop::Registration m_exception;
     /// The connection that was made to the IP address
     std::shared_ptr<openssl::ISslConnection> m_connection;
     /// The time at which the lookup will be considered failed

--- a/include/loop.h
+++ b/include/loop.h
@@ -32,8 +32,8 @@ class Loop : public ILoop
     /// \param callback  The callback to call if it triggers
     /// \param timeout  The time at which to call exception on the handle
     ///
-    /// \return  True if the handle is not already registered and now is
-    bool registerRead(int handle, Callback callback, time_t timeout) override;
+    /// \return  A registration which is valid on success
+    Registration registerRead(int handle, Callback callback, time_t timeout) override;
 
     /// \brief   Register for write availability on a given handle
     ///
@@ -41,17 +41,18 @@ class Loop : public ILoop
     /// \param callback  The callback to call if it triggers
     /// \param timeout  The time at which to call exception on the handle
     ///
-    /// \return  True if the handle is not already registered and now is
-    bool registerWrite(int handle, Callback callback, time_t timeout) override;
+    /// \return  A registration which is valid on success
+    Registration registerWrite(int handle, Callback callback, time_t timeout) override;
 
     /// \brief  Register for exceptions on a given handle
     ///
     /// \param handle    The handle to register for exceptions
     /// \param callback  The callback to call if it triggers
     ///
-    /// \return  True if the handle is not already registered and now is
-    bool registerException(int handle, Callback callback) override;
+    /// \return  A registration which is valid on success
+    Registration registerException(int handle, Callback callback) override;
 
+  private:
     /// \brief  Remove a read handle from the loop
     ///
     /// \param handle  The handle to remove read handles for
@@ -67,7 +68,6 @@ class Loop : public ILoop
     /// \param handle  The handle to remove exception handles for
     void removeException(int handle) override;
 
-  private:
     /// \brief  Call a callback in a set of functions
     ///
     /// \param functions  The functions to lookup the callback in

--- a/include/server.h
+++ b/include/server.h
@@ -2,13 +2,13 @@
 #pragma once
 
 #include "config_parser.h"
+#include "i_loop.h"
 
 #include <vector>
 #include <memory>
 
 namespace dote {
 
-class ILoop;
 class Socket;
 class IForwarders;
 
@@ -46,8 +46,9 @@ class Server
     std::shared_ptr<ILoop> m_loop;
     /// The available forwarders
     std::shared_ptr<IForwarders> m_forwarders;
-    /// The sockets that we are recieving from
-    std::vector<std::shared_ptr<Socket>> m_serverSockets;
+    using SocketAndRegistration = std::pair<std::shared_ptr<Socket>, ILoop::Registration>;
+    /// The sockets that we are recieving from and their read registrations.
+    std::vector<SocketAndRegistration> m_serverSockets;
 };
 
 }  // namespace dote

--- a/include/vyatta_check.h
+++ b/include/vyatta_check.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "config_parser.h"
+#include "i_loop.h"
 
 namespace dote {
 
@@ -41,6 +42,8 @@ class VyattaCheck
     
     /// A handle to the inotify watch on the configuration file
     int m_fd;
+    /// The read registration for m_fd.
+    ILoop::Registration m_read;
     /// The main DoTe instance to configure on configuration changes
     Dote* m_dote;
     /// The base configuration to augment

--- a/src/client_forwarders.cpp
+++ b/src/client_forwarders.cpp
@@ -94,9 +94,7 @@ ClientForwarders::ClientForwarders(std::shared_ptr<ILoop> loop,
     m_loop(std::move(loop)),
     m_config(std::move(config)),
     m_ssl(std::move(ssl)),
-    m_maxConnections(maxConnections),
-    m_forwarders(),
-    m_queue()
+    m_maxConnections(maxConnections)
 { }
 
 ClientForwarders::~ClientForwarders() noexcept

--- a/src/config_parser.cpp
+++ b/src/config_parser.cpp
@@ -23,13 +23,7 @@ constexpr std::size_t DEFAULT_MAX_CONNECTIONS = 5u;
 
 ConfigParser::ConfigParser() :
     m_valid(true),
-    m_partialForwarder(),
-    m_forwarders(),
-    m_servers(),
-    m_ipLookup(),
-    m_ciphers(),
     m_maxConnections(DEFAULT_MAX_CONNECTIONS),
-    m_pidFile(),
     m_daemonise(false),
     m_timeout(5u)
 {

--- a/src/forwarder_config.cpp
+++ b/src/forwarder_config.cpp
@@ -11,8 +11,7 @@
 namespace dote {
 
 ForwarderConfig::ForwarderConfig() :
-    m_timeout(5),
-    m_forwarders()
+    m_timeout(5)
 { }
 
 void ForwarderConfig::clear()
@@ -50,7 +49,7 @@ std::vector<ConfigParser::Forwarder>::const_iterator ForwarderConfig::end() cons
     return m_forwarders.cend();
 }
 
-void ForwarderConfig::setBad(const ConfigParser::Forwarder &config)
+void ForwarderConfig::setBad(const ConfigParser::Forwarder& config)
 {
     // Look for the config in the forwarder list and move it to the end
     for (auto it = m_forwarders.begin(); it != m_forwarders.end(); ++it)

--- a/src/i_loop.cpp
+++ b/src/i_loop.cpp
@@ -1,0 +1,59 @@
+#include "i_loop.h"
+
+namespace dote {
+
+ILoop::Registration::Registration(ILoop* loop, int handle, Type type) :
+    m_loop(loop),
+    m_handle(handle),
+    m_type(type)
+{ }
+
+ILoop::Registration::Registration() :
+    m_loop(nullptr),
+    m_handle(-1),
+    m_type(Type::Moved)
+{ }
+
+ILoop::Registration::Registration(Registration&& other) :
+    m_loop(other.m_loop),
+    m_handle(other.m_handle),
+    m_type(other.m_type)
+{
+    other.m_type = Type::Moved;
+}
+
+ILoop::Registration& ILoop::Registration::operator=(Registration&& other)
+{
+    std::swap(m_loop, other.m_loop);
+    std::swap(m_handle, other.m_handle);
+    std::swap(m_type, other.m_type);
+    return *this;
+}
+
+ILoop::Registration::~Registration()
+{
+    reset();
+}
+
+void ILoop::Registration::reset() {
+    switch (m_type) {
+        case Moved:
+            break;
+        case Read:
+            m_loop->removeRead(m_handle);
+            break;
+        case Write:
+            m_loop->removeWrite(m_handle);
+            break;
+        case Exception:
+            m_loop->removeException(m_handle);
+            break;
+    }
+    m_type = Type::Moved;
+}
+
+bool ILoop::Registration::valid() const {
+    return m_type != Type::Moved;
+}
+
+}  // namespace dote

--- a/src/ip_lookup.cpp
+++ b/src/ip_lookup.cpp
@@ -22,7 +22,7 @@ IpLookup::IpLookup(const ConfigParser& config) :
     );
     m_connection = std::make_shared<openssl::SslConnection>(context);
     m_connection->setSocket(m_socket->get());
-    m_loop->registerException(
+    m_exception = m_loop->registerException(
         m_socket->get(),
         std::bind(&IpLookup::connect, this, _1)
     );
@@ -37,27 +37,32 @@ IpLookup::~IpLookup()
 
 void IpLookup::connect(int handle)
 {
-    m_loop->removeWrite(handle);
-    m_loop->removeRead(handle);
-
     switch (m_connection->connect())
     {
         case openssl::SslConnection::Result::NEED_READ:
-            m_loop->registerRead(
-                m_socket->get(),
-                std::bind(&IpLookup::connect, this, _1),
-                m_timeout
-            );
+            if (!m_read)
+            {
+                m_read = m_loop->registerRead(
+                    m_socket->get(),
+                    std::bind(&IpLookup::connect, this, _1),
+                    m_timeout
+                );
+            }
+            m_write.reset();
             break;
         case openssl::SslConnection::Result::NEED_WRITE:
-            m_loop->registerWrite(
-                m_socket->get(),
-                std::bind(&IpLookup::connect, this, _1),
-                m_timeout
-            );
+            if (!m_write)
+            {
+                m_write = m_loop->registerWrite(
+                    m_socket->get(),
+                    std::bind(&IpLookup::connect, this, _1),
+                    m_timeout
+                );
+            }
+            m_read.reset();
             break;
         default:
-            m_loop->removeException(handle);
+            m_exception.reset();
             break;
     }
 }

--- a/src/openssl/context.cpp
+++ b/src/openssl/context.cpp
@@ -36,8 +36,7 @@ constexpr int ALLOWED_ERRORS[] = {
 
 Context::Context(const std::string& ciphers) :
     m_context(nullptr),
-    m_session(nullptr),
-    m_chainVerifier()
+    m_session(nullptr)
 {
     // Flag to track if we've tried initialising the OpenSSL
     // library yet because we shouldn't keep trying

--- a/src/openssl/ssl_connection.cpp
+++ b/src/openssl/ssl_connection.cpp
@@ -44,8 +44,7 @@ T certificateOperation(T(CertificateUtilities::*utility)(), SSL* ssl)
 
 SslConnection::SslConnection(std::shared_ptr<Context> context) :
     m_context(std::move(context)),
-    m_ssl(nullptr),
-    m_verifier()
+    m_ssl(nullptr)
 {
     if (m_context)
     {

--- a/src/pid_file.cpp
+++ b/src/pid_file.cpp
@@ -18,11 +18,11 @@ PidFile::PidFile(const std::string& filename) :
         m_handle = open(filename.c_str(), O_RDWR | O_CREAT, 0640);
         if (m_handle < 0)
         {
-            dote::Log::err << "Unable to open PID file";
+            Log::err << "Unable to open PID file";
         }
         else if (lockf(m_handle, F_TLOCK, 0) < 0)
         {
-            dote::Log::err << "Unable to lock PID file";
+            Log::err << "Unable to lock PID file";
             close(m_handle);
             m_handle = -1;
         }
@@ -34,7 +34,7 @@ PidFile::PidFile(const std::string& filename) :
         if (write(m_handle, contents.c_str(), contents.length()) !=
                 contents.length())
         {
-            dote::Log::err << "Unable to write the PID to the PID file";
+            Log::err << "Unable to write the PID to the PID file";
             (void) close(m_handle);
             m_handle = -1;
             (void) unlink(m_filename.c_str());

--- a/src/verify_cache.cpp
+++ b/src/verify_cache.cpp
@@ -9,9 +9,7 @@ namespace dote {
 
 VerifyCache::VerifyCache(openssl::Context::Verifier verifier, int timeout) :
     m_verifier(verifier),
-    m_timeout(timeout),
-    m_cache(),
-    m_expiry()
+    m_timeout(timeout)
 { }
 
 int VerifyCache::forwardVerify(X509_STORE_CTX* context)

--- a/src/vyatta_check.cpp
+++ b/src/vyatta_check.cpp
@@ -42,14 +42,6 @@ VyattaCheck::~VyattaCheck()
 {
     if (m_fd >= 0)
     {
-        if (m_dote)
-        {
-            auto loop = m_dote->looper();
-            if (loop)
-            {
-                loop->removeRead(m_fd);
-            }
-        }
         close(m_fd);
     }
 }
@@ -69,7 +61,7 @@ void VyattaCheck::configure(Dote& dote)
     if (loop && m_fd >= 0)
     {
         m_dote = &dote;
-        loop->registerRead(
+        m_read = loop->registerRead(
             m_fd,
             std::bind(&VyattaCheck::handleRead, this, std::placeholders::_1),
             0u

--- a/test/mock_loop.h
+++ b/test/mock_loop.h
@@ -13,9 +13,9 @@ class MockLoop : public ILoop
     ~MockLoop() noexcept
     { }
 
-    MOCK_METHOD3(registerRead, bool(int, Callback, time_t));
-    MOCK_METHOD3(registerWrite, bool(int, Callback, time_t));
-    MOCK_METHOD2(registerException, bool(int, Callback));
+    MOCK_METHOD3(registerRead, ILoop::Registration(int, Callback, time_t));
+    MOCK_METHOD3(registerWrite, ILoop::Registration(int, Callback, time_t));
+    MOCK_METHOD2(registerException, ILoop::Registration(int, Callback));
     MOCK_METHOD1(removeRead, void(int));
     MOCK_METHOD1(removeWrite, void(int));
     MOCK_METHOD1(removeException, void(int));

--- a/test/test_server.cpp
+++ b/test/test_server.cpp
@@ -43,7 +43,7 @@ class TestServer : public ::testing::Test
             .WillOnce(Invoke([this](int handle, ILoop::Callback callback, time_t timeout) {
                 m_handle = handle;
                 m_callback = std::move(callback);
-                return true;
+                return ILoop::Registration(m_loop.get(), m_handle, ILoop::Read);
             }));
         ASSERT_TRUE(m_server.addServer(m_config));
         ASSERT_TRUE(m_callback);


### PR DESCRIPTION
There's probably a number of situations where registrations with the loop are left behind and cause issues.  Instead, use RAII to avoid this.