### PR TITLE
Correct reset

### DIFF
--- a/src/forwarder_connection.cpp
+++ b/src/forwarder_connection.cpp
@@ -110,7 +110,7 @@ void ForwarderConnection::connect(int handle)
                     m_timeout
                 );
             }
-            m_write.reset();
+            m_read.reset();
             break;
         case openssl::SslConnection::Result::SUCCESS:
             // Remove the handlers to add the running ones.


### PR DESCRIPTION
Accidentally reset the m_write rather than m_read when needing to write.